### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,42 @@ Each source will require a different set of arugments to indicate the desired li
 | Argument    | Description                                       | Optional  |
 |-------------|---------------------------------------------------|-----------|
 | --url<br>-u | The URL of the page that contains the live stream | Mandatory |
+
+## Running in background as a service
+
+**Note:** The following instructions only apply for *Linux* distributions using *systemd*.
+
+Create the following service file: /usr/lib/systemd/system/stream-to-m3u@.service
+```
+[Unit]
+Description=Stream to M3U (%i playlist)
+
+[Service]
+WorkingDirectory=/home/horatiu/services
+ExecStart=stream-to-m3u -i /home/horatiu/in.xml -O /srv/http/iptv/playlist-%i.m3u -u http://mydomain.com/iptv
+MemoryAccounting=yes
+MemoryMax=256M
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Create the following timer file: /lib/systemd/system/stream-to-m3u.timer
+```
+[Unit]
+Description=Periodically creates an M3U playlist out of livestreams (%i playlist)
+
+[Timer]
+OnBootSec=3min
+OnUnitActiveSec=40min
+
+[Install]
+WantedBy=timers.target
+```
+
+Values that you might want to change:
+ - *OnBootSec*: the delay before the service is started after the OS is booted
+ - *OnUnitActiveSec*: how often the service will be triggered
+ - *MemoryMax*: RAM usage limit
+
+In the above example, the service will start 3 minutes after boot, and then again once every 40 minutes, being allocated 256M RAM per instance

--- a/Service/PlaylistFileGenerator.cs
+++ b/Service/PlaylistFileGenerator.cs
@@ -181,7 +181,7 @@ namespace StreamToM3U.Service
                 .RemovePunctuation()
                 .Replace(" ", "");
             
-            return $"{normalisedChannelName}.m3u";
+            return $"{normalisedChannelName}.m3u8";
         }
     }
 }

--- a/Service/PlaylistFileGenerator.cs
+++ b/Service/PlaylistFileGenerator.cs
@@ -157,7 +157,7 @@ namespace StreamToM3U.Service
                 
                 foreach (string url in channelUrls[channelName])
                 {
-                    channelFileLines.Add($"#EXTINF:-1,{channelName}");
+                    channelFileLines.Add($"#EXT-X-STREAM-INF:BANDWIDTH=873");
                     channelFileLines.Add(url);
                 }
 

--- a/Service/PlaylistUrlRetriever.cs
+++ b/Service/PlaylistUrlRetriever.cs
@@ -24,17 +24,25 @@ namespace StreamToM3U.Service
             string url = await FindStreamUrl(streamInfo);
             string content = await downloader.TryDownloadStringAsync(url);
 
-            List<string> httpSources = new List<string>();
+            List<string> contentLines = new List<string>();
 
             if (!string.IsNullOrWhiteSpace(content))
             {
-                httpSources = content
+                contentLines = content
                     .Replace("\r", "")
                     .Split("\n")
-                    .Where(x => !string.IsNullOrWhiteSpace(x) && !x.StartsWith("#"))
-                    .Select(x=> ProcessStreamUrl(url, x))
                     .ToList();
             }
+
+            if (!contentLines.Any() || !contentLines.First().StartsWith("#EXTM3U"))
+            {
+                return null;
+            }
+
+            List<string> httpSources = contentLines
+                .Where(x => !string.IsNullOrWhiteSpace(x) && !x.StartsWith("#"))
+                .Select(x=> ProcessStreamUrl(url, x))
+                .ToList();
 
             if (httpSources.Any())
             {

--- a/Service/Processors/TwitchProcessor.cs
+++ b/Service/Processors/TwitchProcessor.cs
@@ -51,12 +51,12 @@ namespace StreamToM3U.Service.Processors
                 return string.Format(
                     PlaylistUrlFormat,
                     streamInfo.ChannelId,
-                    UrlEcodeToken(token),
+                    UrlEncodeToken(token),
                     signature);
             }
         }
 
-        private string UrlEcodeToken(string token)
+        private string UrlEncodeToken(string token)
         {
             string processedToken = token.Replace("\\\"", "\"");
 


### PR DESCRIPTION
 - Fixed channel M3U tags (for TiviMate)
 - Changed channel playlist extension to M3U8
 - Retrieve stream URLs from inside the main stream URL when possible
 - Filter out stale URLs